### PR TITLE
【Fixed】'rails g'コマンドの際にassetsファイル、helperが作成されないように改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,8 @@ module Achieve
     config.action_view.field_error_proc = proc { |html_tag, instance| html_tag }
 
     config.generators do |g|
+      g.assets false
+      g.helper false
       g.test_framework :rspec,
         fixture: true,
         view_specs: false,


### PR DESCRIPTION
#1

config/application.rb
`config.generators do |g|`配下に、
`g.assets false`
`g.helper false`
を追加