### PR TITLE
【Fixed】デバッグツールをdevelopmentのみ反映されるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem 'therubyracer', platforms: :ruby
 group :development do
   gem 'letter_opener_web'
   gem 'web-console', '~> 2.0'
+  gem 'pry-rails'
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 group :development, :test do
@@ -44,9 +47,6 @@ group :development, :test do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-
-  gem 'pry-rails'
-  gem 'better_errors'
 
   gem 'capistrano', '3.6.0'
   gem 'capistrano-bundler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -524,6 +524,7 @@ PLATFORMS
 DEPENDENCIES
   activeresource
   better_errors
+  binding_of_caller
   byebug
   cancan
   capistrano (= 3.6.0)


### PR DESCRIPTION
#2

下記のgemを`group :development do`配下に記述するようにしました。
`gem 'pry-rails'`
`gem 'better_errors'`
`gem 'binding_of_caller'`